### PR TITLE
Avoid using freetype2 system dependency

### DIFF
--- a/pango-build/meson.build
+++ b/pango-build/meson.build
@@ -18,4 +18,5 @@ project('pango-build', 'c', 'cpp',
 )
 
 subproject('proxy-libintl')
+subproject('freetype2')
 subproject('pango')

--- a/pango-build/meson.build
+++ b/pango-build/meson.build
@@ -14,6 +14,7 @@ project('pango-build', 'c', 'cpp',
         'glib:sysprof=disabled',
         'pango:build-testsuite=false',
         'harfbuzz:cairo=disabled', # not strictly needed and allows a recursive dependency
+        'freetype:harfbuzz=disabled'
     ],
 )
 

--- a/pango-build/meson.build
+++ b/pango-build/meson.build
@@ -14,10 +14,9 @@ project('pango-build', 'c', 'cpp',
         'glib:sysprof=disabled',
         'pango:build-testsuite=false',
         'harfbuzz:cairo=disabled', # not strictly needed and allows a recursive dependency
-        'freetype:harfbuzz=disabled'
+        'harfbuzz:freetype=disabled' # this backend not required
     ],
 )
 
 subproject('proxy-libintl')
-subproject('freetype2')
 subproject('pango')


### PR DESCRIPTION
harfbuzz finds the system version of freetype and somehow messes up with this build. Now, we disabled it to avoid this issue.